### PR TITLE
clean up calculation of hp_mean in diff/ciede2000

### DIFF
--- a/src/colorio/diff/_ciede2000.py
+++ b/src/colorio/diff/_ciede2000.py
@@ -42,17 +42,10 @@ def ciede2000(
     Lp_mean = (L1 + L2) / 2
     Cp_mean = (C1p + C2p) / 2
 
-    # TODO clean this up
-    hp_mean = np.empty_like(h1p)
-    hp_avg = (h1p + h2p) / 2
-    idx = np.abs(hp_diff) <= 180
-    hp_mean[idx] = hp_avg[idx]
-    idx = ~(np.abs(hp_diff) <= 180) & (hp_avg < 180)
-    hp_mean[idx] = hp_avg[idx] + 180
-    idx = ~(np.abs(hp_diff) <= 180) & (hp_avg >= 180)
-    hp_mean[idx] = hp_avg[idx] - 180
-    idx = (C1p == 0.0) | (C2p == 0.0)
-    hp_mean[idx] = 2 * hp_avg[idx]
+    hp_mean = np.asarray((h1p + h2p) / 2)
+
+    idx = np.abs(hp_diff) > 180
+    hp_mean[idx] = (hp_mean[idx] - 180) % 360
 
     T = (
         1.0


### PR DESCRIPTION
We do not have to care about
```    
idx = (C1p == 0.0) | (C2p == 0.0)
hp_mean[idx] = 2 * hp_avg[idx]
```
because `hp_mean` is only used in parts of the calculation in which `dHp` is involved which is always zero when `C1p` or `C2p` is zero.
When `~(np.abs(hp_diff) <= 180) & (hp_avg < 180)`  is true, the result of `(h1p + h2p) / 2`  is between 90 and 180 and we add 180. So `hp_mean` is between 270 and 360.
When `~(np.abs(hp_diff) <= 180) & (hp_avg >= 180)`  is true, the result of `(h1p + h2p) / 2`  is between 180 and 270 and we subtract 180. So `hp_mean` is between 0 and 90.
The result of `(((h1p + h2p) / 2) - 180) % 360` gives the same results.

